### PR TITLE
FIX: Extract registry values from value-type tuples

### DIFF
--- a/micorsoft_api.py
+++ b/micorsoft_api.py
@@ -87,10 +87,10 @@ def is_same_os(a, b):
 def get_build_number():
     k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r'SOFTWARE\Microsoft\Windows NT\CurrentVersion')
 
-    major = winreg.QueryValueEx(k, 'CurrentMajorVersionNumber')
-    minor = winreg.QueryValueEx(k, 'CurrentMinorVersionNumber')
-    build_number = winreg.QueryValueEx(k, 'CurrentBuildNumber')
-    ubr = winreg.QueryValueEx(k, 'UBR')
+    major = winreg.QueryValueEx(k, 'CurrentMajorVersionNumber')[0]
+    minor = winreg.QueryValueEx(k, 'CurrentMinorVersionNumber')[0]
+    build_number = winreg.QueryValueEx(k, 'CurrentBuildNumber')[0]
+    ubr = winreg.QueryValueEx(k, 'UBR')[0]
 
     return f'{major}.{minor}.{build_number}.{ubr}'
 


### PR DESCRIPTION
The Registry API returns (value, type) tuples, but we only need the value for the version string. 

I can rebase this on the pyproject PR if needed.